### PR TITLE
Move variables to playbooks

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -15,6 +15,10 @@ jobs:
   test_with_molecule:
     runs-on: macos-latest
 
+    strategy:
+      matrix:
+        type: [ novars, usevars ]
+
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -29,6 +33,9 @@ jobs:
         if [ -f requirements.yml ] ; then
           ansible-galaxy install -r requirements.yml
         fi
+
+    - name: Write out inventory file for testing mode
+       run: echo "[{{ matrix.type }}]\nlocalhost" > molecule/ci/cigroups
 
     - name: Run molecule test suite
       run: |

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Write out inventory file for testing mode
       run: |
         echo "[${{ matrix.type }}]" > molecule/ci/cigroups
-        echo "localhost" >> molecule/ci/cigroups
+        echo $(hostname) >> molecule/ci/cigroups
 
     - name: Run molecule test suite
       run: |

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -35,7 +35,7 @@ jobs:
         fi
 
     - name: Write out inventory file for testing mode
-       run: 'echo "[${{ matrix.type }}]\nlocalhost" > molecule/ci/cigroups'
+      run: echo "[${{ matrix.type }}]\nlocalhost" > molecule/ci/cigroups
 
     - name: Run molecule test suite
       run: |

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -35,7 +35,7 @@ jobs:
         fi
 
     - name: Write out inventory file for testing mode
-       run: echo "[${{ matrix.type }}]\nlocalhost" > molecule/ci/cigroups
+       run: 'echo "[${{ matrix.type }}]\nlocalhost" > molecule/ci/cigroups'
 
     - name: Run molecule test suite
       run: |

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -35,7 +35,7 @@ jobs:
         fi
 
     - name: Write out inventory file for testing mode
-       run: echo "[{{ matrix.type }}]\nlocalhost" > molecule/ci/cigroups
+       run: echo "[${{ matrix.type }}]\nlocalhost" > molecule/ci/cigroups
 
     - name: Run molecule test suite
       run: |

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -35,7 +35,9 @@ jobs:
         fi
 
     - name: Write out inventory file for testing mode
-      run: echo "[${{ matrix.type }}]\nlocalhost" > molecule/ci/cigroups
+      run: |
+        echo "[${{ matrix.type }}]" > molecule/ci/cigroups
+        echo "localhost" >> molecule/ci/cigroups
 
     - name: Run molecule test suite
       run: |

--- a/molecule/ci/molecule.yml
+++ b/molecule/ci/molecule.yml
@@ -11,5 +11,7 @@ platforms:
   - name: instance
 provisioner:
   name: ansible
+  playbooks:
+    converge: ../default/converge.yml
 verifier:
   name: ansible

--- a/molecule/ci/molecule.yml
+++ b/molecule/ci/molecule.yml
@@ -11,6 +11,8 @@ platforms:
   - name: instance
 provisioner:
   name: ansible
+  ansible_args:
+    - --inventory=cigroups
   playbooks:
     converge: ../default/converge.yml
 verifier:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,5 +1,20 @@
 ---
-- name: Converge
-  hosts: all
+- name: Converge with default role variables
+  hosts: novars
+  roles:
+    - role: ansible-role-macos-defaults
+
+- name: Converge with custom role variables
+  hosts: usevars
+  vars:
+    dock_orientation: "left"
+    dock_autohide: "true"
+    dock_autohide_delay: 0
+    mail_shortcuts:
+      - { key: '\033Mail\033Services\033OmniFocus 3: Send to Inbox', value: '@^,' }
+      - { key: '\033Message\033Move to\033UlmerNET\033receipts', value: '^r' }
+      - { key: 'Insert Bulleted List', value: '@~\U005B' }
+    global_shortcuts:
+      - { key: 'Save as PDF', value: '@p' }
   roles:
     - role: ansible-role-macos-defaults

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,10 +12,10 @@ lint: |
   flake8
 
 platforms:
-  - name: macos-mojave
+  - name: macos-usevars
     groups:
       - usevars
-    box: msl/macos_mojave_10.14
+    box: macinbox
 
 provisioner:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,6 +12,11 @@ lint: |
   flake8
 
 platforms:
+  - name: macos-novars
+    groups:
+      - novars
+    box: macinbox
+
   - name: macos-usevars
     groups:
       - usevars

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -24,19 +24,6 @@ platforms:
 
 provisioner:
   name: ansible
-  inventory:
-    group_vars:
-      usevars:
-        dock_orientation: "left"
-        dock_autohide: "true"
-        dock_autohide_delay: 0
-        mail_shortcuts:
-          - { key: '\033Mail\033Services\033OmniFocus 3: Send to Inbox', value: '@^,' }
-          - { key: '\033Message\033Move to\033UlmerNET\033receipts', value: '^r' }
-          - { key: 'Insert Bulleted List', value: '@~\U005B' }
-        global_shortcuts:
-          - { key: 'Save as PDF', value: '@p' }
-
   log: True
 
 verifier:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,8 +4,6 @@ dependency:
 
 driver:
   name: vagrant
-  provider:
-    name: vmware_desktop
 
 lint: |
   set -e
@@ -18,10 +16,6 @@ platforms:
     groups:
       - usevars
     box: msl/macos_mojave_10.14
-    memory: 2048
-    cpus: 2
-    config_options:
-      synced_folder: False
 
 provisioner:
   name: ansible

--- a/tasks/trackpad.yml
+++ b/tasks/trackpad.yml
@@ -46,4 +46,3 @@
     type: int
     value: "{{ trackpad_tap_to_click|bool|ternary('1', '0') }}"
   when: trackpad_tap_to_click is not none
-


### PR DESCRIPTION
Move variables with which the role is tested out of molecule.yml and into converge.yml. This way we can share the converge playbook between scenarios and test multiple variable combinations per test run.

This updates makes it so we test the role with no variables set by the end-user, and some common ones set by the end-user.